### PR TITLE
Trim markdown output to remove whitespaces

### DIFF
--- a/docx2md.php
+++ b/docx2md.php
@@ -117,6 +117,13 @@ function docx2md($args) {
 	$processor->importStyleSheet($xslDocument);
 	$markdown = $processor->transformToXml($intermediaryDocument);
 
+	// Trim lines so we have no space in the beginning
+	$lines = explode("\n", $markdown);
+	for ($i=0; $i<count($lines); $i++) {
+		$lines[$i] = trim($lines[$i]);
+	}
+	$markdown = implode("\n", $lines);
+
 	//==========================================================================
 	// Step 5: If the Markdown output file was specified, write it. Otherwise
 	// just write to STDOUT (echo)


### PR DESCRIPTION
Just a small change to trim the output string in order to remove whitespaces. Great script, Mathieu!
